### PR TITLE
Fix setup instructions and missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Optionally change any default [settings](https://hacklabsguitar.github.io/helix-
 Create an API instance.
 
 ```python
-import helixapi
+from helixapi.helix import Helix
 
 helix = Helix()
 ```
@@ -103,7 +103,7 @@ helix = Helix()
 This will load a default empty bundle template. You can instead load your own bundle:
 
 ```python
-import helixapi
+from helixapi.helix import Helix
 
 helix = Helix(file_path="/path/to/bundle.hlb")
 ```

--- a/README.md
+++ b/README.md
@@ -63,11 +63,30 @@ Your contributions are greatly appreciated!
 
 ## Getting Started
 
-Download and install the API
+This project requires Python 3.11. Choose one of the setup methods below:
+
+### Option A: Using uv (Recommended)
+
+[uv](https://docs.astral.sh/uv/) is a fast Python package and project manager.
 
 ```bash
-git clone https://github.com/HackLabsGuitar/`Helix-py-api`.git
-cd `Helix-py-api`
+git clone https://github.com/HackLabsGuitar/helix-py-api.git
+cd helix-py-api
+uv venv
+source .venv/bin/activate
+uv pip install -r requirements.txt
+```
+
+### Option B: Using pyenv
+
+[pyenv](https://github.com/pyenv/pyenv) lets you easily switch between multiple versions of Python.
+
+```bash
+git clone https://github.com/HackLabsGuitar/helix-py-api.git
+cd helix-py-api
+pyenv install
+python -m venv venv
+source venv/bin/activate
 pip install -r requirements.txt
 ```
 

--- a/helixapi/templates/preset.hlx
+++ b/helixapi/templates/preset.hlx
@@ -5,9 +5,12 @@
   "meta" : {
    "application" : "HX Edit",
    "appversion" : 57671680,
+   "author" : "",
+   "band" : "",
    "build_sha" : "39f7f9a",
    "modifieddate" : 1715640960,
-   "name" : "New Preset"
+   "name" : "New Preset",
+   "song" : ""
   },
   "tone" : {
    "dsp0" : {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML
 colorlog
 mido
+python-rtmidi


### PR DESCRIPTION
- Add Python 3.11 requirement with uv and pyenv setup instructions
- Add missing python-rtmidi dependency
- Add missing author, band, and song fields to preset template
- Fix incorrect import statement in README examples